### PR TITLE
Minor Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+JUGGLUCO_DIRECTORY ?= /home/jka/src/android/Glucodata
+
 all: html.xml
 html2xml: html2xml.cpp
-	 g++ -I/home/jka/src/android/Glucodata/Common/src/main/cpp/ -I/home/jka/src/android/Glucodata/Common/src/main/cpp/share -g -std=c++20 $^ -o $@
+	 g++ -I$(JUGGLUCO_DIRECTORY)/Common/src/main/cpp/ -I$(JUGGLUCO_DIRECTORY)/Common/src/main/cpp/share -g -std=c++20 $^ -o $@
 #	g++ -g -std=c++20 html2xml.cpp -o html2xml
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ html2xml: html2xml.cpp
 
 FILES=ringtone.html reminders.html connectionoverview.html addconnection.html locationpermission.html introhelp.html searchhelp.html shortcuthelp.html labelhelp.html settinghelp.html sensorhelp.html kerfstok.html   getlib.html newlabelhelp.html battery.html nutrients.html mealhelp.html colorhelp.html stathelp.html alarmhelp.html flashpermission.html nearbypermission.html watchinfo.html wearosinfo.html about.html disturbhelp.html libreview.html garminconfig.html librenumhelp.html setlibrenumtype.html  floatingconfig.html getaccountidhelp.html Nightscouthelp.html NightPost.html notificationpermission.html staticnum.html talkhelp.html nightnumhelp.html helpexport.html newamount.html healthpermission.html IOB.html  changestart.html camerapermission.html
 
-html.xml: ${FILES}
-	 ./html2xml  $^ > $@
+html.xml: ${FILES} html2xml
+	 ./html2xml  ${FILES} > $@
 
 install: html.xml
 	cp html.xml /o/home/jka/src/android/Glucodata/Common/src/mobile/res/values

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,9 @@ JUGGLUCO_DIRECTORY ?= /home/jka/src/android/Glucodata
 all: html.xml
 html2xml: html2xml.cpp
 	 g++ -I$(JUGGLUCO_DIRECTORY)/Common/src/main/cpp/ -I$(JUGGLUCO_DIRECTORY)/Common/src/main/cpp/share -g -std=c++20 $^ -o $@
-#	g++ -g -std=c++20 html2xml.cpp -o html2xml
-
 
 FILES=ringtone.html reminders.html connectionoverview.html addconnection.html locationpermission.html introhelp.html searchhelp.html shortcuthelp.html labelhelp.html settinghelp.html sensorhelp.html kerfstok.html   getlib.html newlabelhelp.html battery.html nutrients.html mealhelp.html colorhelp.html stathelp.html alarmhelp.html flashpermission.html nearbypermission.html watchinfo.html wearosinfo.html about.html disturbhelp.html libreview.html garminconfig.html librenumhelp.html setlibrenumtype.html  floatingconfig.html getaccountidhelp.html Nightscouthelp.html NightPost.html notificationpermission.html staticnum.html talkhelp.html nightnumhelp.html helpexport.html newamount.html healthpermission.html IOB.html  changestart.html camerapermission.html
 
-#html.xml:ringtone.html reminders.html connectionoverview.html addconnection.html locationpermission.html introhelp.html searchhelp.html shortcuthelp.html labelhelp.html settinghelp.html sensorhelp.html kerfstok.html   getlib.html newlabelhelp.html battery.html nutrients.html mealhelp.html colorhelp.html stathelp.html alarmhelp.html flashpermission.html nearbypermission.html watchinfo.html wearosinfo.html about.html disturbhelp.html libreview.html garminconfig.html librenumhelp.html setlibrenumtype.html 
 html.xml: ${FILES}
 	 ./html2xml  $^ > $@
 
@@ -29,6 +26,3 @@ help: helptexts.zip
 	make -C it ithelptexts.zip 
 	make -C pt pthelptexts.zip 
 	cp helptexts.zip pt/pthelptexts.zip de/dehelptexts.zip nl/nlhelptexts.zip it/ithelptexts.zip /home/jka/html/j-kaltes.github.io/Juggluco/translation
-
-
-	


### PR DESCRIPTION
html.xml can now be built with just `make` rather than `make html2xml && make`. (The first time I ran `make` I got "./html2xml: not found".)

The `JUGGLUCO_DIRECTORY` variable can now be used to specify the Juggluco directory (needed to compile html2xml). By default the original hardcoded path (`/home/jka/src/android/Glucodata`) will be used.